### PR TITLE
Fixed Issue #16

### DIFF
--- a/routes/terminal.js
+++ b/routes/terminal.js
@@ -143,10 +143,10 @@ router.put('/:id', async (req, res) => {
     }
   }
 
-  /* * Send the Response
-   * Finally send the formatted Feedback to the client.
+  /* * Send 200
+   * Finally inform the client that the Feedback was received and saved.
    */
-  res.send(req.body);
+  res.status(200);
 });
 
 /* * */


### PR DESCRIPTION
The API now sends only status 200 back to the client because in this PUT request the Feedback item is not actually formatted, but instead saved directly to the {row} object.